### PR TITLE
Support for Swift 5.3 on Linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 
 /**
 *  Ink

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-    <img src="https://img.shields.io/badge/Swift-5.1-orange.svg" />
+    <img src="https://img.shields.io/badge/Swift-5.2-orange.svg" />
     <a href="https://swift.org/package-manager">
         <img src="https://img.shields.io/badge/swiftpm-compatible-brightgreen.svg?style=flat" alt="Swift Package Manager" />
     </a>
@@ -86,6 +86,12 @@ Ink was designed to be as fast and efficient as possible, to enable hundreds of 
 
 1. Ink aims to get as close to `O(N)` complexity as possible, by minimizing the amount of times it needs to read the Markdown strings that are passed to it, and by optimizing its HTML rendering to be completely linear. While *true* `O(N)` complexity is impossible to achieve when it comes to Markdown parsing, because of its very flexible syntax, the goal is to come as close to that target as possible.
 2. A high degree of memory efficiency is achieved thanks to Swift’s powerful `String` API, which Ink makes full use of — by using string indexes, ranges and substrings, rather than performing unnecessary string copying between its various operations.
+
+## System requirements
+
+To be able to successfully use Ink, make sure that your system has Swift version 5.2 (or later) installed. If you’re using a Mac, also make sure that `xcode-select` is pointed at an Xcode installation that includes the required version of Swift, and that you’re running macOS Catalina (10.15) or later.
+
+Please note that Ink **does not** officially support any form of beta software, including beta versions of Xcode and macOS, or unreleased versions of Swift.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ Ink supports the following Markdown features:
 - Horizontal lines can be placed using either three asterisks (`***`) or three dashes (`---`) on a new line.
 - HTML can be inlined both at the root level, and within text paragraphs.
 - Blockquotes can be created by placing a greater-than arrow at the start of a line, like this: `> This is a blockquote`.
+- Tables can be created using the following syntax (the line consisting of dashes (`-`) can be omitted to create a table without a header row):
+```
+| Header | Header 2 |
+| ------ | -------- |
+| Row 1  | Cell 1   |
+| Row 2  | Cell 2   |
+```
 
 Please note that, being a very young implementation, Ink does not fully support all Markdown specs, such as [CommonMark](https://commonmark.org). Ink definitely aims to cover as much ground as possible, and to include support for the most commonly used Markdown features, but if complete CommonMark compatibility is what you’re looking for — then you might want to check out tools like [CMark](https://github.com/commonmark/cmark).
 

--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -127,6 +127,7 @@ private extension MarkdownParser {
              "*" where character == nextCharacter:
             return HorizontalLine.self
         case "-", "*", "+", \.isNumber: return List.self
+        case "|": return Table.self
         default: return Paragraph.self
         }
     }

--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -67,7 +67,9 @@ public struct MarkdownParser {
                 let type = fragmentType(for: reader.currentCharacter,
                                         nextCharacter: reader.nextCharacter)
 
-                #if swift(>=5.3)
+                #if swift(>=5.4)
+                #warning("review compiler crash work-around below")
+                #elseif swift(>=5.3)
                 // inline function call to work around https://bugs.swift.org/browse/SR-13645
                 let fragment: ParsedFragment = try {
                     let startIndex = reader.currentIndex

--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -67,7 +67,17 @@ public struct MarkdownParser {
                 let type = fragmentType(for: reader.currentCharacter,
                                         nextCharacter: reader.nextCharacter)
 
+                #if swift(>=5.3)
+                // inline function call to work around https://bugs.swift.org/browse/SR-13645
+                let fragment: ParsedFragment = try {
+                    let startIndex = reader.currentIndex
+                    let fragment = try type.readOrRewind(using: &reader)
+                    let rawString = reader.characters(in: startIndex..<reader.currentIndex)
+                    return ParsedFragment(fragment: fragment, rawString: rawString)
+                }()
+                #else
                 let fragment = try makeFragment(using: type.readOrRewind, reader: &reader)
+                #endif
                 fragments.append(fragment)
 
                 if titleHeading == nil, let heading = fragment.fragment as? Heading {

--- a/Sources/Ink/API/Modifier.swift
+++ b/Sources/Ink/API/Modifier.swift
@@ -52,5 +52,6 @@ public extension Modifier {
         case links
         case lists
         case paragraphs
+        case tables
     }
 }

--- a/Sources/Ink/Internal/Heading.swift
+++ b/Sources/Ink/Internal/Heading.swift
@@ -14,7 +14,7 @@ internal struct Heading: Fragment {
         let level = reader.readCount(of: "#")
         try require(level > 0 && level < 7)
         try reader.readWhitespaces()
-        let text = FormattedText.read(using: &reader, terminator: "\n")
+        let text = FormattedText.read(using: &reader, terminators: ["\n"])
 
         return Heading(level: level, text: text)
     }

--- a/Sources/Ink/Internal/Link.swift
+++ b/Sources/Ink/Internal/Link.swift
@@ -12,7 +12,7 @@ internal struct Link: Fragment {
 
     static func read(using reader: inout Reader) throws -> Link {
         try reader.read("[")
-        let text = FormattedText.read(using: &reader, terminator: "]")
+        let text = FormattedText.read(using: &reader, terminators: ["]"])
         try reader.read("]")
 
         guard !reader.didReachEnd else { throw Reader.Error() }

--- a/Sources/Ink/Internal/Table.swift
+++ b/Sources/Ink/Internal/Table.swift
@@ -1,0 +1,219 @@
+/**
+ *  Ink
+ *  Copyright (c) John Sundell 2020
+ *  MIT license, see LICENSE file for details
+ */
+
+import Foundation
+
+struct Table: Fragment {
+    var modifierTarget: Modifier.Target { .tables }
+
+    private var header: Row?
+    private var rows = [Row]()
+    private var columnCount = 0
+    private var columnAlignments = [ColumnAlignment]()
+
+    static func read(using reader: inout Reader) throws -> Table {
+        var table = Table()
+
+        while !reader.didReachEnd, !reader.currentCharacter.isNewline {
+            guard reader.currentCharacter == "|" else {
+                break
+            }
+
+            let row = try reader.readTableRow()
+            table.rows.append(row)
+            table.columnCount = max(table.columnCount, row.count)
+        }
+
+        guard !table.rows.isEmpty else { throw Reader.Error() }
+        table.formHeaderAndColumnAlignmentsIfNeeded()
+        return table
+    }
+
+    func html(usingURLs urls: NamedURLCollection,
+              modifiers: ModifierCollection) -> String {
+        var html = ""
+        let render: () -> String = { "<table>\(html)</table>" }
+
+        if let header = header {
+            let rowHTML = self.html(
+                forRow: header,
+                cellElementName: "th",
+                urls: urls,
+                modifiers: modifiers
+            )
+
+            html.append("<thead>\(rowHTML)</thead>")
+        }
+
+        guard !rows.isEmpty else {
+            return render()
+        }
+
+        html.append("<tbody>")
+
+        for row in rows {
+            let rowHTML = self.html(
+                forRow: row,
+                cellElementName: "td",
+                urls: urls,
+                modifiers: modifiers
+            )
+
+            html.append(rowHTML)
+        }
+
+        html.append("</tbody>")
+        return render()
+    }
+
+    func plainText() -> String {
+        var text = header.map(plainText) ?? ""
+
+        for row in rows {
+            if !text.isEmpty { text.append("\n") }
+            text.append(plainText(forRow: row))
+        }
+
+        return text
+    }
+}
+
+private extension Table {
+    typealias Row = [FormattedText]
+    typealias Cell = FormattedText
+
+    static let delimiters: Set<Character> = ["|", "\n"]
+    static let allowedHeaderCharacters: Set<Character> = ["-", ":"]
+
+    enum ColumnAlignment {
+        case none
+        case left
+        case center
+        case right
+
+        var attribute: String {
+            switch self {
+            case .none:
+                return ""
+            case .left:
+                return #" align="left""#
+            case .center:
+                return #" align="center""#
+            case .right:
+                return #" align="right""#
+            }
+        }
+    }
+
+    mutating func formHeaderAndColumnAlignmentsIfNeeded() {
+        guard rows.count > 1 else { return }
+        guard rows[0].count == rows[1].count else { return }
+
+        let textPredicate = Self.allowedHeaderCharacters.contains
+        var alignments = [ColumnAlignment]()
+
+        for cell in rows[1] {
+            let text = cell.plainText()
+
+            guard text.allSatisfy(textPredicate) else {
+                return
+            }
+
+            alignments.append(parseColumnAlignment(from: text))
+        }
+
+        header = rows[0]
+        columnAlignments = alignments
+        rows.removeSubrange(0...1)
+    }
+
+    func parseColumnAlignment(from text: String) -> ColumnAlignment {
+        switch (text.first, text.last) {
+        case (":", ":"):
+            return .center
+        case (":", _):
+            return .left
+        case (_, ":"):
+            return .right
+        default:
+            return .none
+        }
+    }
+
+    func html(forRow row: Row,
+              cellElementName: String,
+              urls: NamedURLCollection,
+              modifiers: ModifierCollection) -> String {
+        var html = "<tr>"
+
+        for index in 0..<columnCount {
+            let cell = index < row.count ? row[index] : nil
+            let contents = cell?.html(usingURLs: urls, modifiers: modifiers)
+
+            html.append(htmlForCell(
+                at: index,
+                contents: contents ?? "",
+                elementName: cellElementName
+            ))
+        }
+
+        return html + "</tr>"
+    }
+
+    func htmlForCell(at index: Int, contents: String, elementName: String) -> String {
+        let alignment = index < columnAlignments.count
+            ? columnAlignments[index]
+            : .none
+
+        let tags = (
+            opening: "<\(elementName)\(alignment.attribute)>",
+            closing: "</\(elementName)>"
+        )
+
+        return tags.opening + contents + tags.closing
+    }
+
+    func plainText(forRow row: Row) -> String {
+        var text = ""
+
+        for index in 0..<columnCount {
+            let cell = index < row.count ? row[index] : nil
+            if index > 0 { text.append(" | ") }
+            text.append(cell?.plainText() ?? "")
+        }
+
+        return text + " |"
+    }
+}
+
+private extension Reader {
+    mutating func readTableRow() throws -> Table.Row {
+        try readTableDelimiter()
+        var row = Table.Row()
+
+        while !didReachEnd {
+            let cell = FormattedText.read(
+                using: &self,
+                terminators: Table.delimiters
+            )
+
+            try readTableDelimiter()
+            row.append(cell)
+
+            if !didReachEnd, currentCharacter.isNewline {
+                advanceIndex()
+                break
+            }
+        }
+
+        return row
+    }
+
+    mutating func readTableDelimiter() throws {
+        try read("|")
+        discardWhitespaces()
+    }
+}

--- a/Tests/InkTests/TableTests.swift
+++ b/Tests/InkTests/TableTests.swift
@@ -1,0 +1,225 @@
+/**
+ *  Ink
+ *  Copyright (c) John Sundell 2020
+ *  MIT license, see LICENSE file for details
+ */
+
+import XCTest
+import Ink
+
+final class TableTests: XCTestCase {
+    func testTableWithoutHeader() {
+        let html = MarkdownParser().html(from: """
+        | HeaderA | HeaderB |
+        | CellA   | CellB   |
+        """)
+
+        XCTAssertEqual(html, """
+        <table><tbody>\
+        <tr><td>HeaderA</td><td>HeaderB</td></tr>\
+        <tr><td>CellA</td><td>CellB</td></tr>\
+        </tbody></table>
+        """)
+    }
+
+    func testTableWithHeader() {
+        let html = MarkdownParser().html(from: """
+        | HeaderA | HeaderB | HeaderC |
+        | ------- | ------- | ------- |
+        | CellA1  | CellB1  | CellC1  |
+        | CellA2  | CellB2  | CellC2  |
+        """)
+
+        XCTAssertEqual(html, """
+        <table>\
+        <thead><tr><th>HeaderA</th><th>HeaderB</th><th>HeaderC</th></tr></thead>\
+        <tbody>\
+        <tr><td>CellA1</td><td>CellB1</td><td>CellC1</td></tr>\
+        <tr><td>CellA2</td><td>CellB2</td><td>CellC2</td></tr>\
+        </tbody>\
+        </table>
+        """)
+    }
+
+    func testTableWithUnalignedColumns() {
+        let html = MarkdownParser().html(from: """
+        | HeaderA                        | HeaderB    | HeaderC |
+        | ------------------------------ | ----------- | ------------ |
+        | CellA1                    | CellB1      | CellC1       |
+        | CellA2                   | CellB2       | CellC2        |
+        """)
+
+        XCTAssertEqual(html, """
+        <table>\
+        <thead><tr><th>HeaderA</th><th>HeaderB</th><th>HeaderC</th></tr></thead>\
+        <tbody>\
+        <tr><td>CellA1</td><td>CellB1</td><td>CellC1</td></tr>\
+        <tr><td>CellA2</td><td>CellB2</td><td>CellC2</td></tr>\
+        </tbody>\
+        </table>
+        """)
+    }
+
+    func testTableWithOnlyHeader() {
+        let html = MarkdownParser().html(from: """
+        | HeaderA   | HeaderB   | HeaderC |
+        | ----------| ----------| ------- |
+        """)
+
+        XCTAssertEqual(html, """
+        <table>\
+        <thead><tr><th>HeaderA</th><th>HeaderB</th><th>HeaderC</th></tr></thead>\
+        </table>
+        """)
+    }
+
+    func testIncompleteTable() {
+        let html = MarkdownParser().html(from: """
+        | one | two |
+        | three |
+        | four | five | six
+        """)
+
+        XCTAssertEqual(html, "<p>| one | two | | three | | four | five | six</p>")
+    }
+
+    func testInvalidTable() {
+        let html = MarkdownParser().html(from: """
+        |123 Not a table
+        """)
+
+        XCTAssertEqual(html, "<p>|123 Not a table</p>")
+    }
+
+    func testTableBetweenParagraphs() {
+        let html = MarkdownParser().html(from: """
+        A paragraph.
+
+        | A | B |
+        | C | D |
+
+        Another paragraph.
+        """)
+
+        XCTAssertEqual(html, """
+        <p>A paragraph.</p>\
+        <table><tbody>\
+        <tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr>\
+        </tbody></table>\
+        <p>Another paragraph.</p>
+        """)
+    }
+
+    func testTableWithUnevenColumns() {
+        let html = MarkdownParser().html(from: """
+        | one | two |
+        | three | four | five |
+
+        | one | two |
+        | three |
+        """)
+
+        XCTAssertEqual(html, """
+        <table><tbody>\
+        <tr><td>one</td><td>two</td><td></td></tr>\
+        <tr><td>three</td><td>four</td><td>five</td></tr>\
+        </tbody></table>\
+        <table><tbody>\
+        <tr><td>one</td><td>two</td></tr>\
+        <tr><td>three</td><td></td></tr>\
+        </tbody></table>
+        """)
+    }
+
+    func testTableWithInternalMarkdown() {
+        let html = MarkdownParser().html(from: """
+        | Table  | Header     | [Link](/uri) |
+        | ------ | ---------- | ------------ |
+        | Some   | *emphasis* | and          |
+        | `code` | in         | table        |
+        """)
+
+        XCTAssertEqual(html, """
+        <table>\
+        <thead>\
+        <tr><th>Table</th><th>Header</th><th><a href="/uri">Link</a></th></tr>\
+        </thead>\
+        <tbody>\
+        <tr><td>Some</td><td><em>emphasis</em></td><td>and</td></tr>\
+        <tr><td><code>code</code></td><td>in</td><td>table</td></tr>\
+        </tbody>\
+        </table>
+        """)
+    }
+
+    func testTableWithAlignment() {
+        let html = MarkdownParser().html(from: """
+        | Left | Center | Right |
+        | :- | :-: | -:|
+        | One | Two | Three |
+        """)
+
+        XCTAssertEqual(html, """
+        <table>\
+        <thead><tr>\
+        <th align="left">Left</th><th align="center">Center</th><th align="right">Right</th>\
+        </tr></thead>\
+        <tbody>\
+        <tr><td align="left">One</td><td align="center">Two</td><td align="right">Three</td></tr>\
+        </tbody>\
+        </table>
+        """)
+    }
+
+    func testMissingPipeEndsTable() {
+        let html = MarkdownParser().html(from: """
+        | HeaderA | HeaderB |
+        | ------- | ------- |
+        | CellA   | CellB   |
+        > Quote
+        """)
+
+        XCTAssertEqual(html, """
+        <table>\
+        <thead><tr><th>HeaderA</th><th>HeaderB</th></tr></thead>\
+        <tbody><tr><td>CellA</td><td>CellB</td></tr></tbody>\
+        </table>\
+        <blockquote><p>Quote</p></blockquote>
+        """)
+    }
+
+    func testHeaderNotParsedForColumnCountMismatch() {
+        let html = MarkdownParser().html(from: """
+        | HeaderA | HeaderB |
+        | ------- |
+        | CellA   | CellB |
+        """)
+
+        XCTAssertEqual(html, """
+        <table><tbody>\
+        <tr><td>HeaderA</td><td>HeaderB</td></tr>\
+        <tr><td>-------</td><td></td></tr>\
+        <tr><td>CellA</td><td>CellB</td></tr>\
+        </tbody></table>
+        """)
+    }
+}
+
+extension TableTests {
+    static var allTests: Linux.TestList<TableTests> {
+        return [
+            ("testTableWithoutHeader", testTableWithoutHeader),
+            ("testTableWithHeader", testTableWithHeader),
+            ("testTableWithUnalignedColumns", testTableWithUnalignedColumns),
+            ("testTableWithOnlyHeader", testTableWithOnlyHeader),
+            ("testIncompleteTable", testIncompleteTable),
+            ("testInvalidTable", testInvalidTable),
+            ("testTableBetweenParagraphs", testTableBetweenParagraphs),
+            ("testTableWithUnevenColumns", testTableWithUnevenColumns),
+            ("testTableWithInternalMarkdown", testTableWithInternalMarkdown),
+            ("testTableWithAlignment", testTableWithAlignment),
+            ("testMissingPipeEndsTable", testMissingPipeEndsTable),
+            ("testHeaderNotParsedForColumnCountMismatch", testHeaderNotParsedForColumnCountMismatch),
+        ]
+    }
+}

--- a/Tests/InkTests/XCTestManifests.swift
+++ b/Tests/InkTests/XCTestManifests.swift
@@ -17,6 +17,7 @@ public func allTests() -> [Linux.TestCase] {
         Linux.makeTestCase(using: ListTests.allTests),
         Linux.makeTestCase(using: MarkdownTests.allTests),
         Linux.makeTestCase(using: ModifierTests.allTests),
+        Linux.makeTestCase(using: TableTests.allTests),
         Linux.makeTestCase(using: TextFormattingTests.allTests)
     ]
 }


### PR DESCRIPTION
This adds a workaround for a compiler crash when compiling with Swift 5.3 on Linux: https://bugs.swift.org/browse/SR-13645

Tests pass on Linux:

```
❯ docker run --rm -v "$PWD":/host -w /host swift:5.3 swift test
[1/16] Compiling InkTests XCTestManifests.swift
[2/16] Compiling InkTests TableTests.swift
[3/16] Compiling InkTests ImageTests.swift
[4/16] Compiling InkTests LinkTests.swift
[5/16] Compiling InkTests TextFormattingTests.swift
[6/16] Compiling InkTests HeadingTests.swift
[7/16] Compiling InkTests HorizontalLineTests.swift
[8/16] Compiling InkTests LinuxCompatibility.swift
[9/16] Compiling InkTests ListTests.swift
[10/16] Compiling InkTests MarkdownTests.swift
[11/16] Compiling InkTests ModifierTests.swift
[12/16] Compiling InkTests CodeTests.swift
[13/16] Compiling InkTests HTMLTests.swift
[14/17] Merging module InkTests
[15/18] Wrapping AST for InkTests for debugging
[16/18] Compiling InkPackageTests LinuxMain.swift
[17/19] Merging module InkPackageTests
[18/19] Wrapping AST for InkPackageTests for debugging
[19/19] Linking InkPackageTests.xctest
Test Suite 'All tests' started at 2020-10-06 06:05:43.251
Test Suite 'debug.xctest' started at 2020-10-06 06:05:43.272
Test Suite 'CodeTests' started at 2020-10-06 06:05:43.272
Test Case 'CodeTests.testInlineCode' started at 2020-10-06 06:05:43.272
Test Case 'CodeTests.testInlineCode' passed (0.0 seconds)
Test Case 'CodeTests.testCodeBlockWithJustBackticks' started at 2020-10-06 06:05:43.273
Test Case 'CodeTests.testCodeBlockWithJustBackticks' passed (0.0 seconds)
Test Case 'CodeTests.testCodeBlockWithBackticksAndLabel' started at 2020-10-06 06:05:43.273
Test Case 'CodeTests.testCodeBlockWithBackticksAndLabel' passed (0.0 seconds)
Test Case 'CodeTests.testCodeBlockWithBackticksAndLabelNeedingTrimming' started at 2020-10-06 06:05:43.273
Test Case 'CodeTests.testCodeBlockWithBackticksAndLabelNeedingTrimming' passed (0.0 seconds)
Test Case 'CodeTests.testCodeBlockManyBackticks' started at 2020-10-06 06:05:43.273
Test Case 'CodeTests.testCodeBlockManyBackticks' passed (0.0 seconds)
Test Case 'CodeTests.testEncodingSpecialCharactersWithinCodeBlock' started at 2020-10-06 06:05:43.273
Test Case 'CodeTests.testEncodingSpecialCharactersWithinCodeBlock' passed (0.0 seconds)
Test Case 'CodeTests.testIgnoringFormattingWithinCodeBlock' started at 2020-10-06 06:05:43.273
Test Case 'CodeTests.testIgnoringFormattingWithinCodeBlock' passed (0.0 seconds)
Test Suite 'CodeTests' passed at 2020-10-06 06:05:43.273
	 Executed 7 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'HeadingTests' started at 2020-10-06 06:05:43.273
Test Case 'HeadingTests.testHeading' started at 2020-10-06 06:05:43.273
Test Case 'HeadingTests.testHeading' passed (0.0 seconds)
Test Case 'HeadingTests.testHeadingsSeparatedBySingleNewline' started at 2020-10-06 06:05:43.273
Test Case 'HeadingTests.testHeadingsSeparatedBySingleNewline' passed (0.0 seconds)
Test Case 'HeadingTests.testHeadingsWithLeadingNumbers' started at 2020-10-06 06:05:43.273
Test Case 'HeadingTests.testHeadingsWithLeadingNumbers' passed (0.0 seconds)
Test Case 'HeadingTests.testHeadingWithPreviousWhitespace' started at 2020-10-06 06:05:43.274
Test Case 'HeadingTests.testHeadingWithPreviousWhitespace' passed (0.0 seconds)
Test Case 'HeadingTests.testHeadingWithPreviousNewlineAndWhitespace' started at 2020-10-06 06:05:43.274
Test Case 'HeadingTests.testHeadingWithPreviousNewlineAndWhitespace' passed (0.0 seconds)
Test Case 'HeadingTests.testInvalidHeaderLevel' started at 2020-10-06 06:05:43.274
Test Case 'HeadingTests.testInvalidHeaderLevel' passed (0.0 seconds)
Test Case 'HeadingTests.testRemovingTrailingMarkersFromHeading' started at 2020-10-06 06:05:43.274
Test Case 'HeadingTests.testRemovingTrailingMarkersFromHeading' passed (0.0 seconds)
Test Case 'HeadingTests.testHeadingWithOnlyTrailingMarkers' started at 2020-10-06 06:05:43.274
Test Case 'HeadingTests.testHeadingWithOnlyTrailingMarkers' passed (0.0 seconds)
Test Suite 'HeadingTests' passed at 2020-10-06 06:05:43.274
	 Executed 8 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'HorizontalLineTests' started at 2020-10-06 06:05:43.274
Test Case 'HorizontalLineTests.testHorizonalLineWithDashes' started at 2020-10-06 06:05:43.274
Test Case 'HorizontalLineTests.testHorizonalLineWithDashes' passed (0.0 seconds)
Test Case 'HorizontalLineTests.testHorizontalLineWithDashesAtTheStartOfString' started at 2020-10-06 06:05:43.274
Test Case 'HorizontalLineTests.testHorizontalLineWithDashesAtTheStartOfString' passed (0.0 seconds)
Test Case 'HorizontalLineTests.testHorizontalLineWithAsterisks' started at 2020-10-06 06:05:43.274
Test Case 'HorizontalLineTests.testHorizontalLineWithAsterisks' passed (0.0 seconds)
Test Suite 'HorizontalLineTests' passed at 2020-10-06 06:05:43.274
	 Executed 3 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
Test Suite 'HTMLTests' started at 2020-10-06 06:05:43.274
Test Case 'HTMLTests.testTopLevelHTML' started at 2020-10-06 06:05:43.274
Test Case 'HTMLTests.testTopLevelHTML' passed (0.0 seconds)
Test Case 'HTMLTests.testNestedTopLevelHTML' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testNestedTopLevelHTML' passed (0.0 seconds)
Test Case 'HTMLTests.testTopLevelHTMLWithPreviousNewline' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testTopLevelHTMLWithPreviousNewline' passed (0.0 seconds)
Test Case 'HTMLTests.testIgnoringFormattingWithinTopLevelHTML' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testIgnoringFormattingWithinTopLevelHTML' passed (0.0 seconds)
Test Case 'HTMLTests.testIgnoringTextFormattingWithinInlineHTML' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testIgnoringTextFormattingWithinInlineHTML' passed (0.0 seconds)
Test Case 'HTMLTests.testIgnoringListsWithinInlineHTML' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testIgnoringListsWithinInlineHTML' passed (0.0 seconds)
Test Case 'HTMLTests.testInlineParagraphTagEndingCurrentParagraph' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testInlineParagraphTagEndingCurrentParagraph' passed (0.0 seconds)
Test Case 'HTMLTests.testTopLevelSelfClosingHTMLElement' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testTopLevelSelfClosingHTMLElement' passed (0.0 seconds)
Test Case 'HTMLTests.testInlineSelfClosingHTMLElement' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testInlineSelfClosingHTMLElement' passed (0.0 seconds)
Test Case 'HTMLTests.testTopLevelHTMLLineBreak' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testTopLevelHTMLLineBreak' passed (0.0 seconds)
Test Case 'HTMLTests.testHTMLComment' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testHTMLComment' passed (0.0 seconds)
Test Case 'HTMLTests.testHTMLEntities' started at 2020-10-06 06:05:43.276
Test Case 'HTMLTests.testHTMLEntities' passed (0.0 seconds)
Test Suite 'HTMLTests' passed at 2020-10-06 06:05:43.276
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ImageTests' started at 2020-10-06 06:05:43.276
Test Case 'ImageTests.testImageWithURL' started at 2020-10-06 06:05:43.276
Test Case 'ImageTests.testImageWithURL' passed (0.0 seconds)
Test Case 'ImageTests.testImageWithReference' started at 2020-10-06 06:05:43.276
Test Case 'ImageTests.testImageWithReference' passed (0.0 seconds)
Test Case 'ImageTests.testImageWithURLAndAltText' started at 2020-10-06 06:05:43.276
Test Case 'ImageTests.testImageWithURLAndAltText' passed (0.0 seconds)
Test Case 'ImageTests.testImageWithReferenceAndAltText' started at 2020-10-06 06:05:43.276
Test Case 'ImageTests.testImageWithReferenceAndAltText' passed (0.0 seconds)
Test Case 'ImageTests.testImageWithinParagraph' started at 2020-10-06 06:05:43.276
Test Case 'ImageTests.testImageWithinParagraph' passed (0.0 seconds)
Test Suite 'ImageTests' passed at 2020-10-06 06:05:43.276
	 Executed 5 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
Test Suite 'LinkTests' started at 2020-10-06 06:05:43.276
Test Case 'LinkTests.testLinkWithURL' started at 2020-10-06 06:05:43.276
Test Case 'LinkTests.testLinkWithURL' passed (0.0 seconds)
Test Case 'LinkTests.testLinkWithReference' started at 2020-10-06 06:05:43.276
Test Case 'LinkTests.testLinkWithReference' passed (0.0 seconds)
Test Case 'LinkTests.testCaseMismatchedLinkWithReference' started at 2020-10-06 06:05:43.276
Test Case 'LinkTests.testCaseMismatchedLinkWithReference' passed (0.002 seconds)
Test Case 'LinkTests.testNumericLinkWithReference' started at 2020-10-06 06:05:43.278
Test Case 'LinkTests.testNumericLinkWithReference' passed (0.0 seconds)
Test Case 'LinkTests.testBoldLinkWithInternalMarkers' started at 2020-10-06 06:05:43.279
Test Case 'LinkTests.testBoldLinkWithInternalMarkers' passed (0.0 seconds)
Test Case 'LinkTests.testBoldLinkWithExternalMarkers' started at 2020-10-06 06:05:43.279
Test Case 'LinkTests.testBoldLinkWithExternalMarkers' passed (0.0 seconds)
Test Case 'LinkTests.testLinkWithUnderscores' started at 2020-10-06 06:05:43.279
Test Case 'LinkTests.testLinkWithUnderscores' passed (0.0 seconds)
Test Case 'LinkTests.testUnterminatedLink' started at 2020-10-06 06:05:43.279
Test Case 'LinkTests.testUnterminatedLink' passed (0.0 seconds)
Test Case 'LinkTests.testLinkWithEscapedSquareBrackets' started at 2020-10-06 06:05:43.279
Test Case 'LinkTests.testLinkWithEscapedSquareBrackets' passed (0.0 seconds)
Test Suite 'LinkTests' passed at 2020-10-06 06:05:43.279
	 Executed 9 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
Test Suite 'ListTests' started at 2020-10-06 06:05:43.279
Test Case 'ListTests.testOrderedList' started at 2020-10-06 06:05:43.279
Test Case 'ListTests.testOrderedList' passed (0.0 seconds)
Test Case 'ListTests.test10DigitOrderedList' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.test10DigitOrderedList' passed (0.0 seconds)
Test Case 'ListTests.testOrderedListParentheses' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testOrderedListParentheses' passed (0.0 seconds)
Test Case 'ListTests.testOrderedListWithoutIncrementedNumbers' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testOrderedListWithoutIncrementedNumbers' passed (0.0 seconds)
Test Case 'ListTests.testOrderedListWithInvalidNumbers' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testOrderedListWithInvalidNumbers' passed (0.0 seconds)
Test Case 'ListTests.testUnorderedList' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testUnorderedList' passed (0.0 seconds)
Test Case 'ListTests.testMixedUnorderedList' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testMixedUnorderedList' passed (0.0 seconds)
Test Case 'ListTests.testMixedList' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testMixedList' passed (0.0 seconds)
Test Case 'ListTests.testUnorderedListWithMultiLineItem' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testUnorderedListWithMultiLineItem' passed (0.0 seconds)
Test Case 'ListTests.testUnorderedListWithNestedList' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testUnorderedListWithNestedList' passed (0.0 seconds)
Test Case 'ListTests.testUnorderedListWithInvalidMarker' started at 2020-10-06 06:05:43.281
Test Case 'ListTests.testUnorderedListWithInvalidMarker' passed (0.0 seconds)
Test Suite 'ListTests' passed at 2020-10-06 06:05:43.281
	 Executed 11 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'MarkdownTests' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testParsingMetadata' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testParsingMetadata' passed (0.0 seconds)
Test Case 'MarkdownTests.testDiscardingEmptyMetadataValues' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testDiscardingEmptyMetadataValues' passed (0.0 seconds)
Test Case 'MarkdownTests.testMergingOrphanMetadataValueIntoPreviousOne' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testMergingOrphanMetadataValueIntoPreviousOne' passed (0.0 seconds)
Test Case 'MarkdownTests.testMissingMetadata' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testMissingMetadata' passed (0.0 seconds)
Test Case 'MarkdownTests.testMetadataModifiers' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testMetadataModifiers' passed (0.0 seconds)
Test Case 'MarkdownTests.testPlainTextTitle' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testPlainTextTitle' passed (0.0 seconds)
Test Case 'MarkdownTests.testRemovingTrailingMarkersFromTitle' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testRemovingTrailingMarkersFromTitle' passed (0.0 seconds)
Test Case 'MarkdownTests.testConvertingFormattedTitleTextToPlainText' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testConvertingFormattedTitleTextToPlainText' passed (0.0 seconds)
Test Case 'MarkdownTests.testTreatingFirstHeadingAsTitle' started at 2020-10-06 06:05:43.282
Test Case 'MarkdownTests.testTreatingFirstHeadingAsTitle' passed (0.0 seconds)
Test Case 'MarkdownTests.testOverridingTitle' started at 2020-10-06 06:05:43.282
Test Case 'MarkdownTests.testOverridingTitle' passed (0.0 seconds)
Test Suite 'MarkdownTests' passed at 2020-10-06 06:05:43.282
	 Executed 10 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ModifierTests' started at 2020-10-06 06:05:43.282
Test Case 'ModifierTests.testModifierInput' started at 2020-10-06 06:05:43.282
Test Case 'ModifierTests.testModifierInput' passed (0.0 seconds)
Test Case 'ModifierTests.testInitializingParserWithModifiers' started at 2020-10-06 06:05:43.282
Test Case 'ModifierTests.testInitializingParserWithModifiers' passed (0.0 seconds)
Test Case 'ModifierTests.testAddingModifiers' started at 2020-10-06 06:05:43.282
Test Case 'ModifierTests.testAddingModifiers' passed (0.0 seconds)
Test Case 'ModifierTests.testMultipleModifiersForSameTarget' started at 2020-10-06 06:05:43.282
Test Case 'ModifierTests.testMultipleModifiersForSameTarget' passed (0.0 seconds)
Test Suite 'ModifierTests' passed at 2020-10-06 06:05:43.282
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
Test Suite 'TableTests' started at 2020-10-06 06:05:43.282
Test Case 'TableTests.testTableWithoutHeader' started at 2020-10-06 06:05:43.282
Test Case 'TableTests.testTableWithoutHeader' passed (0.0 seconds)
Test Case 'TableTests.testTableWithHeader' started at 2020-10-06 06:05:43.282
Test Case 'TableTests.testTableWithHeader' passed (0.0 seconds)
Test Case 'TableTests.testTableWithUnalignedColumns' started at 2020-10-06 06:05:43.283
Test Case 'TableTests.testTableWithUnalignedColumns' passed (0.0 seconds)
Test Case 'TableTests.testTableWithOnlyHeader' started at 2020-10-06 06:05:43.283
Test Case 'TableTests.testTableWithOnlyHeader' passed (0.0 seconds)
Test Case 'TableTests.testIncompleteTable' started at 2020-10-06 06:05:43.283
Test Case 'TableTests.testIncompleteTable' passed (0.0 seconds)
Test Case 'TableTests.testInvalidTable' started at 2020-10-06 06:05:43.284
Test Case 'TableTests.testInvalidTable' passed (0.0 seconds)
Test Case 'TableTests.testTableBetweenParagraphs' started at 2020-10-06 06:05:43.284
Test Case 'TableTests.testTableBetweenParagraphs' passed (0.0 seconds)
Test Case 'TableTests.testTableWithUnevenColumns' started at 2020-10-06 06:05:43.284
Test Case 'TableTests.testTableWithUnevenColumns' passed (0.0 seconds)
Test Case 'TableTests.testTableWithInternalMarkdown' started at 2020-10-06 06:05:43.284
Test Case 'TableTests.testTableWithInternalMarkdown' passed (0.0 seconds)
Test Case 'TableTests.testTableWithAlignment' started at 2020-10-06 06:05:43.284
Test Case 'TableTests.testTableWithAlignment' passed (0.0 seconds)
Test Case 'TableTests.testMissingPipeEndsTable' started at 2020-10-06 06:05:43.285
Test Case 'TableTests.testMissingPipeEndsTable' passed (0.0 seconds)
Test Case 'TableTests.testHeaderNotParsedForColumnCountMismatch' started at 2020-10-06 06:05:43.285
Test Case 'TableTests.testHeaderNotParsedForColumnCountMismatch' passed (0.0 seconds)
Test Suite 'TableTests' passed at 2020-10-06 06:05:43.285
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
Test Suite 'TextFormattingTests' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testParagraph' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testParagraph' passed (0.0 seconds)
Test Case 'TextFormattingTests.testItalicText' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testItalicText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testBoldText' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testBoldText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testItalicBoldText' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testItalicBoldText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testItalicBoldTextWithSeparateStartMarkers' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testItalicBoldTextWithSeparateStartMarkers' passed (0.0 seconds)
Test Case 'TextFormattingTests.testItalicTextWithinBoldText' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testItalicTextWithinBoldText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testBoldTextWithinItalicText' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testBoldTextWithinItalicText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testItalicTextWithExtraLeadingMarkers' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testItalicTextWithExtraLeadingMarkers' passed (0.0 seconds)
Test Case 'TextFormattingTests.testBoldTextWithExtraLeadingMarkers' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testBoldTextWithExtraLeadingMarkers' passed (0.0 seconds)
Test Case 'TextFormattingTests.testItalicTextWithExtraTrailingMarkers' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testItalicTextWithExtraTrailingMarkers' passed (0.0 seconds)
Test Case 'TextFormattingTests.testBoldTextWithExtraTrailingMarkers' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testBoldTextWithExtraTrailingMarkers' passed (0.0 seconds)
Test Case 'TextFormattingTests.testItalicBoldTextWithExtraTrailingMarkers' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testItalicBoldTextWithExtraTrailingMarkers' passed (0.0 seconds)
Test Case 'TextFormattingTests.testUnterminatedItalicMarker' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testUnterminatedItalicMarker' passed (0.0 seconds)
Test Case 'TextFormattingTests.testUnterminatedBoldMarker' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testUnterminatedBoldMarker' passed (0.0 seconds)
Test Case 'TextFormattingTests.testUnterminatedItalicBoldMarker' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testUnterminatedItalicBoldMarker' passed (0.0 seconds)
Test Case 'TextFormattingTests.testUnterminatedItalicMarkerWithinBoldText' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testUnterminatedItalicMarkerWithinBoldText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testUnterminatedBoldMarkerWithinItalicText' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testUnterminatedBoldMarkerWithinItalicText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testStrikethroughText' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testStrikethroughText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testSingleTildeWithinStrikethroughText' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testSingleTildeWithinStrikethroughText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testUnterminatedStrikethroughMarker' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testUnterminatedStrikethroughMarker' passed (0.0 seconds)
Test Case 'TextFormattingTests.testEncodingSpecialCharacters' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testEncodingSpecialCharacters' passed (0.0 seconds)
Test Case 'TextFormattingTests.testSingleLineBlockquote' started at 2020-10-06 06:05:43.287
Test Case 'TextFormattingTests.testSingleLineBlockquote' passed (0.0 seconds)
Test Case 'TextFormattingTests.testMultiLineBlockquote' started at 2020-10-06 06:05:43.287
Test Case 'TextFormattingTests.testMultiLineBlockquote' passed (0.0 seconds)
Test Case 'TextFormattingTests.testEscapingSymbolsWithBackslash' started at 2020-10-06 06:05:43.287
Test Case 'TextFormattingTests.testEscapingSymbolsWithBackslash' passed (0.0 seconds)
Test Case 'TextFormattingTests.testDoubleSpacedHardLinebreak' started at 2020-10-06 06:05:43.287
Test Case 'TextFormattingTests.testDoubleSpacedHardLinebreak' passed (0.0 seconds)
Test Case 'TextFormattingTests.testEscapedHardLinebreak' started at 2020-10-06 06:05:43.287
Test Case 'TextFormattingTests.testEscapedHardLinebreak' passed (0.0 seconds)
Test Suite 'TextFormattingTests' passed at 2020-10-06 06:05:43.287
	 Executed 26 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
Test Suite 'debug.xctest' passed at 2020-10-06 06:05:43.287
	 Executed 107 tests, with 0 failures (0 unexpected) in 0.013 (0.013) seconds
Test Suite 'All tests' passed at 2020-10-06 06:05:43.287
	 Executed 107 tests, with 0 failures (0 unexpected) in 0.013 (0.013) seconds
```

I've also tested they pass for Swift 5.2.4/Linux as well as macOS 5.3.